### PR TITLE
fix: reset the store if contains an invalid value

### DIFF
--- a/src/CookieStore.ts
+++ b/src/CookieStore.ts
@@ -101,20 +101,27 @@ class CookieStore {
     const persistedCookies = localStorage.getItem(PERSISTENCY_KEY)
 
     if (persistedCookies) {
-      try{
+      try {
         const parsedCookies: [string, [string, any]] = JSON.parse(
-          persistedCookies
+          persistedCookies,
         )
-  
+
         parsedCookies.forEach(([origin, cookie]) => {
           this.store.set(origin, new Map(cookie))
         })
-      }catch(_){
-        console.warn(`[MSW] the storage used for cookies has an invalid value "${localStorage.getItem(PERSISTENCY_KEY)}".
-This key is used internally by MSW to store cookies.`)
+      } catch (error) {
+        console.warn(`
+[virtual-cookie] Failed to parse a stored cookie from the localStorage (key "${PERSISTENCY_KEY}").
+
+Stored value:
+${localStorage.getItem(PERSISTENCY_KEY)}
+
+Thrown exception:
+${error}
+
+Invalid value has been removed from localStorage to prevent subsequent failed parsing attempts.`)
         localStorage.removeItem(PERSISTENCY_KEY)
       }
-      
     }
   }
 
@@ -130,7 +137,7 @@ This key is used internally by MSW to store cookies.`)
     const serializedCookies = Array.from(this.store.entries()).map(
       ([origin, cookies]) => {
         return [origin, Array.from(cookies.entries())]
-      }
+      },
     )
 
     localStorage.setItem(PERSISTENCY_KEY, JSON.stringify(serializedCookies))

--- a/src/CookieStore.ts
+++ b/src/CookieStore.ts
@@ -101,13 +101,20 @@ class CookieStore {
     const persistedCookies = localStorage.getItem(PERSISTENCY_KEY)
 
     if (persistedCookies) {
-      const parsedCookies: [string, [string, any]] = JSON.parse(
-        persistedCookies
-      )
-
-      parsedCookies.forEach(([origin, cookie]) => {
-        this.store.set(origin, new Map(cookie))
-      })
+      try{
+        const parsedCookies: [string, [string, any]] = JSON.parse(
+          persistedCookies
+        )
+  
+        parsedCookies.forEach(([origin, cookie]) => {
+          this.store.set(origin, new Map(cookie))
+        })
+      }catch(_){
+        console.warn(`[MSW] the storage used for cookies has an invalid value "${localStorage.getItem(PERSISTENCY_KEY)}".
+This key is used internally by MSW to store cookies.`)
+        localStorage.removeItem(PERSISTENCY_KEY)
+      }
+      
     }
   }
 

--- a/test/invalid-store.test.ts
+++ b/test/invalid-store.test.ts
@@ -1,0 +1,12 @@
+import { store, PERSISTENCY_KEY } from '../src'
+
+afterEach(() => jest.restoreAllMocks())
+test('should reset the store if contains an invalid value', () => {
+  jest.spyOn(global.console, 'warn').mockImplementation(() => {})
+  localStorage.setItem(PERSISTENCY_KEY, 'not valid json')
+
+  expect(() => store.hydrate()).not.toThrow()
+  expect(localStorage.getItem(PERSISTENCY_KEY)).toBeNull()
+  expect(console.warn).toHaveBeenCalledWith(`[MSW] the storage used for cookies has an invalid value "not valid json".
+This key is used internally by MSW to store cookies.`)
+})

--- a/test/invalid-store.test.ts
+++ b/test/invalid-store.test.ts
@@ -7,6 +7,14 @@ test('should reset the store if contains an invalid value', () => {
 
   expect(() => store.hydrate()).not.toThrow()
   expect(localStorage.getItem(PERSISTENCY_KEY)).toBeNull()
-  expect(console.warn).toHaveBeenCalledWith(`[MSW] the storage used for cookies has an invalid value "not valid json".
-This key is used internally by MSW to store cookies.`)
+  expect(console.warn).toHaveBeenCalledWith(`
+[virtual-cookie] Failed to parse a stored cookie from the localStorage (key \"MSW_COOKIE_STORE\").
+
+Stored value:
+not valid json
+
+Thrown exception:
+SyntaxError: Unexpected token o in JSON at position 1
+
+Invalid value has been removed from localStorage to prevent subsequent failed parsing attempts.`)
 })


### PR DESCRIPTION
Because of the `localStorage` is not a private storage, `MSW_COOKIE_STORE` key could contains a non json value. This will throw an error when `hydrate` will be called. 

I have added a `console.warn` to inform the user of the error, and I have deleted the key from the storage. 